### PR TITLE
Add missing windows.h header

### DIFF
--- a/webauthn.h
+++ b/webauthn.h
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include <windows.h>
 #include <winapifamily.h>
 
 #pragma region Desktop Family or OneCore Family


### PR DESCRIPTION
To avoid errors about unknown type name DWORD/PBYTE/LONG/etc