### PR TITLE
Fix email link

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ For more details about the standards, please follow these links:
 
 
 # Having Issues?
-If you have any issues in adopting these APIs or need some clarification, please contact [fido-dev](fido-dev@microsoft.com)
+If you have any issues in adopting these APIs or need some clarification, please contact fido-dev@microsoft.com.
 
 
 # Contributing


### PR DESCRIPTION
The current link can be confused with FIDO Alliance's mailing list, and was broken (no `mailto:`).